### PR TITLE
Release: 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
-## 0.1.0 (Unreleased)
+## 0.1.1
+
+Added additional optional `scope` for data source configuration.
+Provided the data source plugin handling to respect the `hide` query option.
+Improved internal stability of the plugin backend.
+
+## 0.1.0
 
 Initial release.
+Provides basic data source connection to a SurrealDB instance through the configuration of `location`, `namespace`, `database`, `username`, and `password`.
+The query editor provides a `raw`, `log`, and `metric` mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealdb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealdb",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "surrealdb",
   "author": "fiskaly",
   "license": "Apache-2.0",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Grafana Data Source Plugin for SurrealDB",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
This PR introduces the following changes:

* updated package semantic versioning
* provided release change log summary 
* https://github.com/fiskaly/grafana.surrealdb/compare/v0.1.0...release/0.1.1
