### PR TITLE
Metric Grouping

### DIFF
--- a/etc/provisioning/dashboards/Default/default.json
+++ b/etc/provisioning/dashboards/Default/default.json
@@ -57,7 +57,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 9,
         "w": 12,
         "x": 0,
         "y": 0
@@ -128,7 +128,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 13,
+        "h": 9,
         "w": 12,
         "x": 12,
         "y": 0
@@ -229,10 +229,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 0,
-        "y": 5
+        "y": 9
       },
       "id": 3,
       "options": {
@@ -324,17 +324,119 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 15,
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "fiskaly-surrealdb-datasource",
+            "uid": "fiskaly-surrealdb-datasource"
+          },
+          "group": true,
+          "groupBy": "level",
+          "mode": "metric",
+          "rate": true,
+          "rateFunctions": [
+            "count"
+          ],
+          "rateInterval": "10s",
+          "rateZero": true,
+          "refId": "A",
+          "requery": true,
+          "surql": "select * from timeseries:[$from]..[$to]"
+        }
+      ],
+      "title": "Timeseries Rate Grouped By Level",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "fiskaly-surrealdb-datasource",
+        "uid": "fiskaly-surrealdb-datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 19
       },
       "id": 4,
       "interval": "10s",
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "table",
+          "displayMode": "list",
           "placement": "right",
           "showLegend": true
         },
@@ -377,7 +479,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": "",
   "schemaVersion": 38,
   "tags": [],
   "templating": {

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -35,11 +35,17 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
     , timestamp
     , logMessage
     , metricData
+    , group
+    , groupBy
     , rate
     , rateZero
     , rateInterval
     , rateFunctions
     } = query;
+
+    if( query.group === undefined ){
+	query.group = false
+    }
 
     if( query.rate === undefined ){
 	query.rate = false
@@ -194,6 +200,51 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
         disabled={false}
         onChange={(value: string) => {
             onChange({ ...query, metricData: value });
+            if( requery ) {
+                onRunQuery();
+            }
+        }}
+        onBlur={() => {}}
+          />
+          </div>
+        </InlineField>
+}
+      </HorizontalGroup>
+      <HorizontalGroup>
+{ (mode === "metric") &&
+      <InlineField
+        label="Group By"
+        labelWidth={12}
+        tooltip="Enable metric grouping."
+      >
+      <InlineSwitch
+        value={group}
+        disabled={false}
+        transparent={false}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            let checked = event.target.checked;
+            onChange({ ...query, group: checked });
+            if( requery ) {
+                onRunQuery();
+            }
+        }}
+      />
+      </InlineField>
+}
+{ (mode === "metric") && group &&
+      <InlineField
+        label="Field"
+        labelWidth={14}
+        tooltip="Metric group by field."
+      >
+      <div style={{ minWidth: 245 }}>
+      <QueryField
+        placeholder={"group"}
+        portalOrigin=""
+        query={groupBy}
+        disabled={false}
+        onChange={(value: string) => {
+            onChange({ ...query, groupBy: value });
             if( requery ) {
                 onRunQuery();
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface MyQuery extends DataQuery {
     timestamp?: string;
     logMessage?: string;
     metricData?: string;
+    group?: boolean;
+    groupBy?: string;
     rate?: boolean;
     rateZero?: boolean;
     rateInterval?: string;


### PR DESCRIPTION
This PR introduces the following changes:

* provides new `group` functionality in the `metric` query editor mode to `groupBy` the metric value with a provided data column form the queried table result
* the grouping functionality can be either applied to the actual metric value as well as to the underlying `rate` computation functions
* closes #4
