### PR TITLE
6: Dashboard Variable Querying

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - ./.attic/surrealdb:/surreal.db
     command: |
       start
+      --auth
       --log trace
       --user root
       --pass root

--- a/etc/provisioning/dashboards/Default/default.json
+++ b/etc/provisioning/dashboards/Default/default.json
@@ -162,7 +162,7 @@
           "mode": "raw",
           "refId": "A",
           "requery": true,
-          "surql": "select * from timeseries:[$from]..[$to]"
+          "surql": "select * from timeseries:[$from]..[$to] where level in \"$variable\""
         }
       ],
       "title": "Timeseries Data Table",
@@ -257,7 +257,7 @@
           "mode": "raw",
           "refId": "A",
           "requery": true,
-          "surql": "select * from timeseries:..[$to]"
+          "surql": "select * from timeseries:..[$to] where level in \"$variable\""
         }
       ],
       "title": "Timeseries Value",
@@ -359,7 +359,7 @@
           "rateZero": true,
           "refId": "A",
           "requery": true,
-          "surql": "select * from timeseries:[$from]..[$to]"
+          "surql": "select * from timeseries:[$from]..[$to] where level in \"$variable\""
         }
       ],
       "title": "Timeseries Rate Grouped By Level",
@@ -471,7 +471,7 @@
           "rateZero": true,
           "refId": "A",
           "requery": true,
-          "surql": "select * from timeseries:[$from]..[$to]",
+          "surql": "select * from timeseries:[$from]..[$to] where level in \"$variable\"",
           "timestamp": ""
         }
       ],
@@ -483,7 +483,38 @@
   "schemaVersion": 38,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": "",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "fiskaly-surrealdb-datasource",
+          "uid": "fiskaly-surrealdb-datasource"
+        },
+        "definition": "select level from timeseries",
+        "description": "Variable-based query to filter data by log level.",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Log Level",
+        "multi": true,
+        "name": "variable",
+        "options": [],
+        "query": "select level from timeseries",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-2m",

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,8 +1,11 @@
 import
-{ DataSourceInstanceSettings
+{ CoreApp
+, DataSourceInstanceSettings
 , DataQueryRequest
 , DataQueryResponse
-, CoreApp
+, MetricFindValue
+, ScopedVars
+, TimeRange
 } from '@grafana/data';
 
 import
@@ -33,12 +36,84 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
 	return super.query(request);
     }
 
+    filterQuery(query: MyQuery): boolean {
+	if (query.hide || query.surql === '') {
+	    return false;
+	}
+	return true;
+    }
+
     // https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#global-variables
-    applyTemplateVariables(query: MyQuery) {
-	const templateSrv = getTemplateSrv();
+    applyTemplateVariables(query: MyQuery, scopedVars: ScopedVars) {
 	return {
 	    ...query,
-	    surql: templateSrv.replace(query.surql),
+	    surql: getTemplateSrv().replace(query.surql, scopedVars),
 	};
+    }
+
+    // https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/add-support-for-variables#add-support-for-query-variables-to-your-data-source
+    metricFindQuery(surql: string, options: { range: TimeRange, scopedVars: ScopedVars, variable: { id: string }}): Promise<MetricFindValue[]> {
+	let now = new Date();
+	let range = options?.range;
+	let scopedVars = options.scopedVars;
+	let variableId = options.variable.id;
+	let interval = scopedVars?.__interval?.text || "1s"
+	let intervalMs = scopedVars?.__intervalMs?.value || 1000
+
+	let query: MyQuery[] =
+	[ { refId: variableId
+	  , mode: "raw"
+	  , surql: surql
+	  , requery: false
+	  }
+	];
+
+	let request: DataQueryRequest<MyQuery> =
+	{ requestId: variableId
+	, app: "dashboard"
+	, timezone: "browser"
+	, interval: interval
+	, intervalMs: intervalMs
+	, range: range
+	, startTime: now.getTime()
+	, scopedVars: scopedVars
+	, targets: query
+	};
+
+	let observable = super.query(request)
+	return new Promise<MetricFindValue[]>(
+	    (myResolve, myReject) => {
+		let response: any = {}
+
+		observable.subscribe({
+		    next(element) {
+			response = element
+		    },
+		    error(err) {
+			myReject([ { "text": "Query failed: " + err } ])
+		    },
+		    complete() {
+			if( response.state === 'Done' ) {
+			    let values: any[] = []
+
+			    response.data[0].fields[0].values.forEach(
+				(element: any) => {
+				    let text = element
+				    if( typeof text !== "string" ) {
+					text = JSON.stringify(text)
+				    }
+				    values.push( { "text": text } )
+				}
+			    );
+			    myResolve(values)
+			} else if( response.state === 'Error' ) {
+			    myReject([{ "text": response.error.message }])
+			} else {
+			    myReject([{ "text": "Query failed: internal error" }])
+			}
+		    },
+		});
+	    }
+	);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export const DEFAULT_QUERY: Partial<MyQuery> =
 { mode: "raw"
 , surql: "info for database"
 , requery: true
-};
+}
 
 /**
  * These are options configured for each DataSource instance


### PR DESCRIPTION
This PR introduces the following changes:

* provides dashboard variable-based query functionality by implementing the `metricFindQuery` interface
* updated provisioning of default dashboard to demonstrate the variable-based query functionality
* updated `local` deployment configuration
* closes #6 
